### PR TITLE
Add a load of new hackathons from the organiser spreadsheet

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,8 +28,13 @@ This list showcases upcoming UK student-run hackathons.
 |Hackathon        |Website| University         |No. of Hackers|Date|
 |-----------------|-------|--------------------|--------------|----|
 | HackNotts 2019  | [hacknotts.com](https://www.hacknotts.com)  | University of Nottingham  | 200 | 16th-17th November 2019 |
+| Oxford Hack 2019 | [oxfordhack.co.uk](https://oxfordhack.co.uk/) | Oxford University | 300 | 16th-17th November 2019 |
+| Lincoln Hack 2019 | [2019.lincolnhack.org](https://2019.lincolnhack.org/) | Digital Lincoln | ?? | 16th-17th November 2019 |
+| GreatUniHack 2019 | [greatunihack.com](https://greatunihack.com/) | University of Manchester | ?? | 16th-17th November 2019 |
 | DurHack 2019    | [durhack.com](https://durhack.com) | Durham University | 150 | 23rd-24th November 2019 |
+| Royal Hackaway v3 | [royalhackaway.com](https://royalhackaway.com/) | Royal Holloway, University of London | 300 | 8th-9th February 2020 |
 | ManMetHacks 2.0 | [ManMetHacks](https://manmethacks.com) | Manchester Metropolitan University | 150 | 25th-26th January 2019|
+| IC Hack 20      | [ichack.org](https://ichack.org) | Imperial College London | 400 | 8th-9th February 2020 |
 | CovHack 2020    | [covhack.org](https://covhack.org) | Coventry University | 100 | 15th-16th February 2020 |
 
 Want to add something to this list? [Fork and pull request](https://github.com/HHEU/wiki/edit/master/docs/index.md) to add your event!

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ This list showcases upcoming UK student-run hackathons.
 | GreatUniHack 2019 | [greatunihack.com](https://greatunihack.com/) | University of Manchester | ?? | 16th-17th November 2019 |
 | DurHack 2019    | [durhack.com](https://durhack.com) | Durham University | 150 | 23rd-24th November 2019 |
 | Royal Hackaway v3 | [royalhackaway.com](https://royalhackaway.com/) | Royal Holloway, University of London | 300 | 8th-9th February 2020 |
-| ManMetHacks 2.0 | [ManMetHacks](https://manmethacks.com) | Manchester Metropolitan University | 150 | 25th-26th January 2019|
+| ManMetHacks 2.0 | [ManMetHacks](https://manmethacks.com) | Manchester Metropolitan University | 150 | 25th-26th January 2020 |
 | IC Hack 20      | [ichack.org](https://ichack.org) | Imperial College London | 400 | 8th-9th February 2020 |
 | CovHack 2020    | [covhack.org](https://covhack.org) | Coventry University | 100 | 15th-16th February 2020 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,6 @@ This list showcases upcoming UK student-run hackathons.
 |-----------------|-------|--------------------|--------------|----|
 | HackNotts 2019  | [hacknotts.com](https://www.hacknotts.com)  | University of Nottingham  | 200 | 16th-17th November 2019 |
 | Oxford Hack 2019 | [oxfordhack.co.uk](https://oxfordhack.co.uk/) | Oxford University | 300 | 16th-17th November 2019 |
-| Lincoln Hack 2019 | [2019.lincolnhack.org](https://2019.lincolnhack.org/) | Digital Lincoln | ?? | 16th-17th November 2019 |
 | GreatUniHack 2019 | [greatunihack.com](https://greatunihack.com/) | University of Manchester | ?? | 16th-17th November 2019 |
 | DurHack 2019    | [durhack.com](https://durhack.com) | Durham University | 150 | 23rd-24th November 2019 |
 | Royal Hackaway v3 | [royalhackaway.com](https://royalhackaway.com/) | Royal Holloway, University of London | 300 | 8th-9th February 2020 |


### PR DESCRIPTION
- Oxford Hack 2019
- Lincoln Hack 2019
- GreatUniHack 2019
- Royal Hackaway v3
- IC Hack 20

Only 'questionable' one is [Lincoln Hack 2019](https://2019.lincolnhack.org/). From what I can see, it's run by [Digital Lincoln](https://www.digitallincoln.co.uk/) rather than a university society. Thoughts @aaronosher @bahorn ?

**Edit:** Also fixed date for ManMetHacks 2.0