### PR TITLE
Clean up events page

### DIFF
--- a/docs/events/index.md
+++ b/docs/events/index.md
@@ -1,9 +1,11 @@
 ## Finding Events
 
 MLH publishes the list of the Hackathons they are working with
-[here](https://mlh.io/seasons/eu-2020/events).
+[here](https://mlh.io/eu).
 
 Events are normally advertised on
-[Hackathon Hackers EU](https://www.facebook.com/groups/hackathonhackerseu/)
+[Hackathon Hackers EU](https://www.facebook.com/groups/hackathonhackerseu/).
 
 Some events might be listed or use on [Eventbrite](https://eventbrite.co.uk), or registered with [Ti.to](http://ti.to) services or MyMLH, but not every event uses it for tickets.
+
+**This website has a (fairly) comprehensive list of UK hackathons on the [homepage](/).**


### PR DESCRIPTION
- Add a timeless link to MLH's season page (mlh.io/eu will always redirect to the latest season)
- Add a missing full stop
- Link to the HHEU wiki homepage for a (reasonably) full list of events