### PR TITLE
Add drop shadow to .button class

### DIFF
--- a/docs/static/css/home.css
+++ b/docs/static/css/home.css
@@ -13,6 +13,7 @@
     padding: 8px 16px;
     border-radius: 3px;
     background-color: var(--color-primary);
+    box-shadow: 0 0 .2rem rgba(0,0,0,.1),0 .2rem .4rem rgba(0,0,0,.2);
 }
 
 span {


### PR DESCRIPTION
This makes the buttons fit with the material design theme of the site better.

### Before
![image](https://user-images.githubusercontent.com/34094978/71266279-fd6e5680-233f-11ea-89ae-f34b780ebbaa.png)


### After
![image](https://user-images.githubusercontent.com/34094978/71266232-e4fe3c00-233f-11ea-8ab1-a2b848c14dff.png)
