### PR TITLE
Add dates for HackMed 2020

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ This list showcases upcoming UK student-run hackathons and hackathon-associated 
 | HHEU Unconference | [hackathonhackers.eu](https://hackathonhackers.eu) | ?? | ?? | 29th February 2020 |
 | Hack the Burgh | [hacktheburgh.com](https://2020.hacktheburgh.com/) | University of Edinburgh | ?? | 29th February-1st March 2020 |
 | R.U. Hacking? 2020 | [ruhacking.me](https://ruhacking.me) | Reading University | TBC | 7th-8th March 2020 | 
-| HackMed   | [hackmed.uk](http://hackmed.uk/) | University of Sheffield | ?? |  March 2020 |
+| HackMed   | [hackmed.uk](http://hackmed.uk/) | University of Sheffield | ?? |  14th-15th March 2020 |
 | DurHack:NextGen   | [durhack.com/nextgen](https://durhack.com/nextgen) | Durham University | 100 (U18 only!) | 18th-19th April 2020 |
 
 ## Autumn 2020


### PR DESCRIPTION
Taken from the homepage of [hackmed.uk](http://hackmed.uk/).