### PR TITLE
Add hackathons

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -135,6 +135,7 @@ This list showcases past UK student-run hackathons (most recent first).
 | DurHack 2017 | [durhack.com](http://durhack.com) | Durham University | 100 | 9th-10th December 2017 |
 | Sex Tech Hack II | [sexhack.tech](https://sexhack.tech) | Goldsmiths, University of London | 100 | 25th-26th November 2017 | 
 | HackKings 4.0 | [hackkings.org](https://hackkings.org) | King's College London | 200 | 25th-26th November 2017 |
+| OxfordHack 2017 | [oxfordhack.com](http://oxfordhack.com/) | University of Oxford | 200? | 25th-26th November 2017 |
 | Hatch UCL | N/A | University College London | 100 | 25th-26th November 2017 |
 | HackSussex | [hacksussex.com](https://hacksussex.com/) | University of Sussex | 150 | 11th-12th November 2017 |
 | AstonHack | [astonhack.co.uk](https://astonhack.co.uk/) | Aston University, Birmingham | 150 | 11th-12th November 2017 |

--- a/docs/index.md
+++ b/docs/index.md
@@ -103,6 +103,7 @@ This list showcases past UK student-run hackathons (most recent first).
 | HackKings v5.0 | [hackkings.org](https://hackkings.org) | King's College London | 200 | 8th-9th December 2018 |
 | HackNotts 2018  | [hacknotts.com](https://www.hacknotts.com)  | University of Nottingham  | 150 | 25th-26th November 2018 |
 | DurHack 2018   | [durhack.com](https://durhack.com) | Durham University | 150 | 17th-18th November 2018 |
+| Porticode 3.0 | [porticode.org](https://www.porticode.org/) | University College London | ?? | 17th-18th November 2018 |
 | ExImpact | [exeterentrepreneurs.com/eximpact](http://exeterentrepreneurs.com/eximpact/) | University of Exeter | ?? | 16th-18th November 2018 |
 | GreatUniHack 2018 | [greatunihack.com](https://greatunihack.com/) | University of Manchester | 200 | 10th-11th November 2018 |
 | HackSussex 2018 | [hacksussex.com](https://hacksussex.com/) | University of Sussex | 150 | 10th-11th November 2018 |

--- a/docs/index.md
+++ b/docs/index.md
@@ -121,7 +121,7 @@ This list showcases past UK student-run hackathons (most recent first).
 | STACSHack | N/A | St Andrews, UK | 130 | 7th-8th April 2018 | 
 | HackKent | [kentcomputingsociety.co.uk/hackkent](https://kentcomputingsociety.co.uk/hackkent) | University of Kent | N/A | 13th-14th March |
 | HackMed | [hackmed.uk](https://hackmed.uk) | University of Sheffield | 80 | 10th-11th March |
-| Hack the Burgh 2018 | [hacktheburgh.com](https://hacktheburgh.com) |  University of Edinburgh | 150 | 10th-11th March 2018 |
+| Hack the Burgh 2018 | [hacktheburgh.com](https://2018.hacktheburgh.com) |  University of Edinburgh | 150 | 10th-11th March 2018 |
 | BullHacks | [bullhacks.tech/](https://bullhacks.tech/) | Birmingham City University | 100 | 3rd-4th March 2018 |
 | Anvil Hack IV | [goldsmiths.tech/anvil](https://goldsmiths.tech/anvil) | Goldsmiths, University of London | 120 | 24th-25th February 2018 | 
 | HackCity 2018 | N/A | City, University of London | 100 | 17th-18th February 2018 |

--- a/docs/index.md
+++ b/docs/index.md
@@ -137,6 +137,7 @@ This list showcases past UK student-run hackathons (most recent first).
 | HackKings 4.0 | [hackkings.org](https://hackkings.org) | King's College London | 200 | 25th-26th November 2017 |
 | OxfordHack 2017 | [oxfordhack.com](http://oxfordhack.com/) | University of Oxford | 200? | 25th-26th November 2017 |
 | Hatch UCL | N/A | University College London | 100 | 25th-26th November 2017 |
+| BrumHack 7.0 | [brumhack.co.uk](https://www.brumhack.co.uk) | University of Birmingham | ?? | 18th-19th November 2017 |
 | HackSussex | [hacksussex.com](https://hacksussex.com/) | University of Sussex | 150 | 11th-12th November 2017 |
 | AstonHack | [astonhack.co.uk](https://astonhack.co.uk/) | Aston University, Birmingham | 150 | 11th-12th November 2017 |
 | GreatUniHack 2017 | [greatunihack.com](https://greatunihack.com/) | University of Manchester | 200 | 11th-12th November 2017 |

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,6 +95,7 @@ This list showcases past UK student-run hackathons (most recent first).
 | Royal Hackaway v2 | [royalhackaway.com/hackaway2019](https://royalhackaway.com/hackaway2019) | Royal Holloway | 150 | 2nd-3rd February 2019 |
 | IC Hack 19 | [ichack.org](https://ichack.org) | Imperial College London | 400 | 26th-27th January 2019 |
 | ManMetHacks | [manmethacks.com](https://manmethacks.com) | Manchester Metropolitan University | 150 | 26th-27th January 2019 |
+| Hack Cambridge 4D | [hackcambridge.com](https://hackcambridge.com) | University of Cambridge | 300 | 19th-20th January 2019 |
 
 ## Autumn 2018
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -102,6 +102,7 @@ This list showcases past UK student-run hackathons (most recent first).
 | HackKings v5.0 | [hackkings.org](https://hackkings.org) | King's College London | 200 | 8th-9th December 2018 |
 | HackNotts 2018  | [hacknotts.com](https://www.hacknotts.com)  | University of Nottingham  | 150 | 25th-26th November 2018 |
 | DurHack 2018   | [durhack.com](https://durhack.com) | Durham University | 150 | 17th-18th November 2018 |
+| ExImpact | [exeterentrepreneurs.com/eximpact](http://exeterentrepreneurs.com/eximpact/) | University of Exeter | ?? | 16th-18th November 2018 |
 | GreatUniHack 2018 | [greatunihack.com](https://greatunihack.com/) | University of Manchester | 200 | 10th-11th November 2018 |
 | HackSussex 2018 | [hacksussex.com](https://hacksussex.com/) | University of Sussex | 150 | 10th-11th November 2018 |
 | AstonHack | [astonhack.co.uk](https://astonhack.co.uk/) | Aston University, Birmingham | 150 | 10th-11th November 2018 |

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ This list showcases upcoming UK student-run hackathons and hackathon-associated 
 | WarwickHACK 2020 | [warwickhack.com](https://www.warwickhack.com/) | University of Warwick | ?? | 22nd-23rd February 2020 |
 | HackSurrey v3.0 | [hacksurrey.uk](https://hacksurrey.uk/) | University of Surrey | 150 | 22nd-23rd February 2020 |
 | HHEU Unconference | [hackathonhackers.eu](https://hackathonhackers.eu) | ?? | ?? | 29th February 2020 |
-| Hack the Burgh | [hacktheburgh.com](https://2020.hacktheburgh.com/) | University of Edinburgh | ?? | 29th February-1st March 2020 |
+| Hack the Burgh VI | [hacktheburgh.com](https://2020.hacktheburgh.com/) | University of Edinburgh | ?? | 29th February-1st March 2020 |
 | R.U. Hacking? 2020 | [ruhacking.me](https://ruhacking.me) | Reading University | TBC | 7th-8th March 2020 | 
 | HackMed   | [hackmed.uk](http://hackmed.uk/) | University of Sheffield | ?? |  March 2020 |
 | DurHack:NextGen   | [durhack.com/nextgen](https://durhack.com/nextgen) | Durham University | 100 (U18 only!) | 18th-19th April 2020 |

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ This list showcases upcoming UK student-run hackathons and hackathon-associated 
 
 |Hackathon        |Website| University         |No. of Hackers|Date|
 |-----------------|-------|--------------------|--------------|----|
-| Hack Cambridge 2020 | [hackcambridge.com](https://hackcambridge.com) | University of Cambridge | 300 | 18th-19th January 2020 |
+| Hack Cambridge 101 | [hackcambridge.com](https://hackcambridge.com) | University of Cambridge | 300 | 18th-19th January 2020 |
 | ManMetHacks 2.0 | [manmethacks.com](https://manmethacks.com) | Manchester Metropolitan University | 150 | 25th-26th January 2020 |
 | Royal Hackaway v3 | [royalhackaway.com/hackawayv3](https://royalhackaway.com/hackawayv3) | Royal Holloway, University of London | 300 | 1st-2nd February 2020|
 | Quackathon 2020 | [quackathon.com](https://quackathon.com/) | University of Dundee | 100 | 1st-2nd February 2020|

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ This list showcases upcoming UK student-run hackathons and hackathon-associated 
 |-----------------|-------|--------------------|--------------|----|
 | Hack Cambridge 2020 | [hackcambridge.com](https://hackcambridge.com) | University of Cambridge | 300 | 18th-19th January 2020 |
 | ManMetHacks 2.0 | [manmethacks.com](https://manmethacks.com) | Manchester Metropolitan University | 150 | 25th-26th January 2020 |
-| Royal Hackaway v3 | [royalhackaway.com](https://royalhackaway.com/) | Royal Holloway, University of London | 300 | 1st-2nd February 2020|
+| Royal Hackaway v3 | [royalhackaway.com/hackawayv3](https://royalhackaway.com/hackawayv3) | Royal Holloway, University of London | 300 | 1st-2nd February 2020|
 | Quackathon 2020 | [quackathon.com](https://quackathon.com/) | University of Dundee | 100 | 1st-2nd February 2020|
 | IC Hack 20      | [ichack.org](https://ichack.org) | Imperial College London | 400 | 8th-9th February 2020 |
 | CovHack 2020    | [covhack.org](https://covhack.org) | Coventry University | 150 | 15th-16th February 2020 |

--- a/docs/index.md
+++ b/docs/index.md
@@ -126,6 +126,7 @@ This list showcases past UK student-run hackathons (most recent first).
 | Anvil Hack IV | [goldsmiths.tech/anvil](https://goldsmiths.tech/anvil) | Goldsmiths, University of London | 120 | 24th-25th February 2018 | 
 | HackCity 2018 | N/A | City, University of London | 100 | 17th-18th February 2018 |
 | IC Hack 18 | [ichack.org](https://ichack.org) | Imperial College London | 250 | 27th-28th January 2018 |
+| ExHack | [exeterentrepreneurs.com/exhack](http://exeterentrepreneurs.com/exhack/) | University of Exeter | ?? | 26th-28th January 2018 |
 | Global Game Jam @ Goldsmiths | N/A | Goldsmiths, University of London | 100 | 26th-27th January 2018 |
 | Hack Cambridge Ternary | [hackcambridge.com](https://hackcambridge.com/) | University of Cambridge | 300 | 20th-21st January 2018 |
 | Royal Hackaway | [royalhackaway.xyz](https://royalhackaway.xyz/) | Royal Holloway, University of London | ?? | 13th-14th January 2018 |

--- a/docs/index.md
+++ b/docs/index.md
@@ -102,6 +102,7 @@ This list showcases past UK student-run hackathons (most recent first).
 |-----------------|-------|--------------------|--------------|----|
 | HackKings v5.0 | [hackkings.org](https://hackkings.org) | King's College London | 200 | 8th-9th December 2018 |
 | HackNotts 2018  | [hacknotts.com](https://www.hacknotts.com)  | University of Nottingham  | 150 | 25th-26th November 2018 |
+| OxfordHack | [oxfordhack.uk](http://www.oxfordhack.uk/) | University of Oxford | 300 | 25th-26th November 2018 |
 | DurHack 2018   | [durhack.com](https://durhack.com) | Durham University | 150 | 17th-18th November 2018 |
 | Porticode 3.0 | [porticode.org](https://www.porticode.org/) | University College London | ?? | 17th-18th November 2018 |
 | ExImpact | [exeterentrepreneurs.com/eximpact](http://exeterentrepreneurs.com/eximpact/) | University of Exeter | ?? | 16th-18th November 2018 |

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,6 +88,7 @@ This list showcases past UK student-run hackathons (most recent first).
 |-----------------|-------|--------------------|--------------|----|
 | HackMed   | [hackmed.uk](http://hackmed.uk/) | University of Sheffield | 100 | 30th-31st March 2019 |
 | CovHack 19   | [covhack.org](https://covhack.org) | Coventry University | 110 | 16th-17th March 2019 |
+| Hack the Burgh V | [hacktheburgh.com](https://2019.hacktheburgh.com) | University of Edinburgh | 200 | 16th-17th March 2019 |
 | R. U. Hacking? 2019   | [ruhacking.me](https://ruhacking.me) | University of Reading | 150 | 16th-17th February 2019 |
 | HackSurrey Mk2 | [mk2.hacksurrey.uk](https://mk2.hacksurrey.uk) | University of Surrey | 150 | 9th-10th February 2019 |
 | Hack The South | [hackthesouth.co.uk](https://hackthesouth.co.uk/) | University of Southampton | 150 | 9th-10th February 2019 |

--- a/docs/index.md
+++ b/docs/index.md
@@ -127,6 +127,7 @@ This list showcases past UK student-run hackathons (most recent first).
 | HackCity 2018 | N/A | City, University of London | 100 | 17th-18th February 2018 |
 | IC Hack 18 | [ichack.org](https://ichack.org) | Imperial College London | 250 | 27th-28th January 2018 |
 | Global Game Jam @ Goldsmiths | N/A | Goldsmiths, University of London | 100 | 26th-27th January 2018 |
+| Royal Hackaway | [royalhackaway.xyz](https://royalhackaway.xyz/) | Royal Holloway, University of London | ?? | 13th-14th January 2018 |
 
 ## Autumn 2017
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ This list showcases upcoming UK student-run hackathons and hackathon-associated 
 | Royal Hackaway v3 | [royalhackaway.com/hackawayv3](https://royalhackaway.com/hackawayv3) | Royal Holloway, University of London | 300 | 1st-2nd February 2020|
 | Quackathon 2020 | [quackathon.com](https://quackathon.com/) | University of Dundee | 100 | 1st-2nd February 2020|
 | IC Hack 20      | [ichack.org](https://ichack.org) | Imperial College London | 400 | 8th-9th February 2020 |
-| CovHack 2020    | [covhack.org](https://covhack.org) | Coventry University | 150 | 15th-16th February 2020 |
+| CovHack2020    | [covhack.org](https://covhack.org) | Coventry University | 150 | 15th-16th February 2020 |
 | JunctionX Exeter | [hackjunction.com](https://www.hackjunction.com/concepts/junction-x) | University of Exeter | ?? | 21st-23rd February 2020 |
 | RGUHack 2020    | [rguhack.uk](https://rguhack.uk)   | Robert Gordon University, Aberdeen | 80 | 22nd-23rd February 2020 |
 | WarwickHACK 2020 | [warwickhack.com](https://www.warwickhack.com/) | University of Warwick | ?? | 22nd-23rd February 2020 |

--- a/docs/index.md
+++ b/docs/index.md
@@ -127,6 +127,7 @@ This list showcases past UK student-run hackathons (most recent first).
 | HackCity 2018 | N/A | City, University of London | 100 | 17th-18th February 2018 |
 | IC Hack 18 | [ichack.org](https://ichack.org) | Imperial College London | 250 | 27th-28th January 2018 |
 | Global Game Jam @ Goldsmiths | N/A | Goldsmiths, University of London | 100 | 26th-27th January 2018 |
+| Hack Cambridge Ternary | [hackcambridge.com](https://hackcambridge.com/) | University of Cambridge | 300 | 20th-21st January 2018 |
 | Royal Hackaway | [royalhackaway.xyz](https://royalhackaway.xyz/) | Royal Holloway, University of London | ?? | 13th-14th January 2018 |
 
 ## Autumn 2017

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,6 +79,7 @@ This list showcases past UK student-run hackathons (most recent first).
 | AstonHack 2019 | [astonhack.co.uk](https://astonhack.co.uk/) | Aston University, Birmingham | 175 | 2nd-3rd November 2019 |
 | HackTheMidlands 4.0 | [hackthemidlands.com](https://Hackthemidlands.com/) | Millennium Point, Curzon St, Birmingham B4 7XG | 300 | 26th-27th October 2019 |
 | HackBrunel | [hackbrunel.com](https://hackbrunel.com/) | Brunel University | 100 | 26th-27th October 2019 |
+| Do You Have The GUTS? | [gutechsoc.com/hackathon](https://gutechsoc.com/hackathon) | University of Glasgow | 300 | 18th-20th October 2019 |
 | HHEU Unconference | [hackathonhackers.eu](https://hackathonhackers.eu) | Nottingham University | 25 | 5th October 2019 |
 
 ## Spring 2019
@@ -106,6 +107,7 @@ This list showcases past UK student-run hackathons (most recent first).
 | AstonHack | [astonhack.co.uk](https://astonhack.co.uk/) | Aston University, Birmingham | 150 | 10th-11th November 2018 |
 | HackTheMidlands 3.0 | [hackthemidlands.com](https://Hackthemidlands.com/) | Millennium Point, Curzon St, Birmingham B4 7XG | 200 | 3rd-4th November 2018 |
 | hackSheffield 4 | [hacksheffield.co](https://hacksheffield.co/) | University of Sheffield | 200 | 27th-28th October 2019 |
+| Do You Have The GUTS? | [gutechsoc.com/hackathon](https://gutechsoc.com/hackathon) | University of Glasgow | ?? | 12th-14th October 2018 |
 
 ## Spring 2018
 
@@ -136,6 +138,7 @@ This list showcases past UK student-run hackathons (most recent first).
 | AstonHack | [astonhack.co.uk](https://astonhack.co.uk/) | Aston University, Birmingham | 150 | 11th-12th November 2017 |
 | GreatUniHack 2017 | [greatunihack.com](https://greatunihack.com/) | University of Manchester | 200 | 11th-12th November 2017 |
 | HackNotts 2017  | [hacknotts.com](https://www.hacknotts.com)  | University of Nottingham  | 150 | 28th-29th October 2017 |
+| Do You Have The Guts | [gutechsoc.com/hackathon](https://gutechsoc.com/hackathon) | University of Glasgow | ?? | 27th-29th October 2017 |
 | hackSheffield 3 | [hacksheffield.co](https://hacksheffield.co/) | University of Sheffield | 200 | 14th-15th October 2017 |
 | HackTheMidlands 2.0 | [hackthemidlands.com](https://hackthemidlands.com/) | Millennium Point, Birmingham | 150 | 23rd-24th September 2017 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -141,6 +141,7 @@ This list showcases past UK student-run hackathons (most recent first).
 | AstonHack | [astonhack.co.uk](https://astonhack.co.uk/) | Aston University, Birmingham | 150 | 11th-12th November 2017 |
 | GreatUniHack 2017 | [greatunihack.com](https://greatunihack.com/) | University of Manchester | 200 | 11th-12th November 2017 |
 | HackNotts 2017  | [hacknotts.com](https://www.hacknotts.com)  | University of Nottingham  | 150 | 28th-29th October 2017 |
+| Porticode 2.0 | [porticode.io](https://porticode.io/) | University College London | ?? | 28th-29th October 2017 |
 | Do You Have The Guts | [gutechsoc.com/hackathon](https://gutechsoc.com/hackathon) | University of Glasgow | ?? | 27th-29th October 2017 |
 | hackSheffield 3 | [hacksheffield.co](https://hacksheffield.co/) | University of Sheffield | 200 | 14th-15th October 2017 |
 | HackTheMidlands 2.0 | [hackthemidlands.com](https://hackthemidlands.com/) | Millennium Point, Birmingham | 150 | 23rd-24th September 2017 |


### PR DESCRIPTION
# New Hackathons
Added the following hackathons:

- Do You Have The Guts (2017)
- Do You Have The GUTS? (2018)
- Do You Have The GUTS? (2019)
- ExImpact (2018)
- Hack The Burgh V (2019)
- OxfordHack 2017
- Porticode 2.0 (2017)
- BrumHack 7.0 (2017)
- Royal Hackaway (2018)
- Hack Cambridge Ternary (2018)
- ExHack (2018)
- Porticode 3.0 (2018)
- OxfordHack (2018)

This should cover all MLH events from the 2018 season (which starts in autumn 2017) through to today. This also includes a few events I've discovered through other means.

# Fixes
Made the following fixes:
- Added iteration (`VI`) to Hack The Burgh VI
- Updated URL for Hack the Burgh 2018
- Updated link for Royal Hackaway v3
- Corrected name of CovHack2020 (can you confirm this is correct @bahorn ?)
- Fixed name of Hack Cambridge 101