### PR TITLE
Add Leeds hackathon (2018)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -112,7 +112,7 @@ This list showcases past UK student-run hackathons (most recent first).
 | HackSussex 2018 | [hacksussex.com](https://hacksussex.com/) | University of Sussex | 150 | 10th-11th November 2018 |
 | AstonHack | [astonhack.co.uk](https://astonhack.co.uk/) | Aston University, Birmingham | 150 | 10th-11th November 2018 |
 | HackTheMidlands 3.0 | [hackthemidlands.com](https://Hackthemidlands.com/) | Millennium Point, Curzon St, Birmingham B4 7XG | 200 | 3rd-4th November 2018 |
-| hackSheffield 4 | [hacksheffield.co](https://hacksheffield.co/) | University of Sheffield | 200 | 27th-28th October 2019 |
+| hackSheffield 4 | [hacksheffield.co](https://hacksheffield.co/) | University of Sheffield | 200 | 27th-28th October 2018 |
 | Do You Have The GUTS? | [gutechsoc.com/hackathon](https://gutechsoc.com/hackathon) | University of Glasgow | ?? | 12th-14th October 2018 |
 
 ## Spring 2018

--- a/docs/index.md
+++ b/docs/index.md
@@ -113,6 +113,7 @@ This list showcases past UK student-run hackathons (most recent first).
 | AstonHack | [astonhack.co.uk](https://astonhack.co.uk/) | Aston University, Birmingham | 150 | 10th-11th November 2018 |
 | HackTheMidlands 3.0 | [hackthemidlands.com](https://Hackthemidlands.com/) | Millennium Point, Curzon St, Birmingham B4 7XG | 200 | 3rd-4th November 2018 |
 | hackSheffield 4 | [hacksheffield.co](https://hacksheffield.co/) | University of Sheffield | 200 | 27th-28th October 2018 |
+| Leeds Hackathon | [hackathon.leeds.ac.uk](https://hackathon.leeds.ac.uk/) | University of Leeds | ?? | 26th-28th October 2018 |
 | Do You Have The GUTS? | [gutechsoc.com/hackathon](https://gutechsoc.com/hackathon) | University of Glasgow | ?? | 12th-14th October 2018 |
 
 ## Spring 2018


### PR DESCRIPTION
- Add Leeds hackathon (2018)
- Fix year of hackSheffield 4 (from 2019 to 2018)